### PR TITLE
Optimize and cache project roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ It's also possible to sort buffers by that column by calling `ibuffer-do-sort-by
               (ibuffer-do-sort-by-project-file-relative))))
 ```
 
+### Clearing the cache
+
+For performance, this package stores the locations of projects in memory. To clear the cache, run `ibuffer-project-clear-group-cache`.
+
 ## Installation
 
 ### With `package.el`

--- a/ibuffer-project.el
+++ b/ibuffer-project.el
@@ -66,15 +66,19 @@
 (defun ibuffer-project-root (buf)
   "Return a cons cell (project-root . root-type) for BUF."
   (unless (string-match-p "^ " (buffer-name buf))
-    (with-current-buffer buf
-      (let ((dir (cdr (project-current))))
-        (cond
-         (dir (cons dir 'project))
-         (default-directory (cons (abbreviate-file-name default-directory) 'directory)))))))
+    (let* ((dir (buffer-local-value 'default-directory buf))
+           (root (when dir (cdr (project-current nil dir)))))
+      (cond
+       (root (cons root 'project))
+       (dir (cons (abbreviate-file-name dir) 'directory))))))
 
 (defun ibuffer-project-group-name (root type)
   "Return group name for project ROOT and TYPE."
-  (format "%s: %s" (if (eq type 'project) "Project" "Directory") root))
+  (format "%s: %s"
+          (cl-case type
+            (project "Project")
+            (otherwise "Directory"))
+          root))
 
 (define-ibuffer-filter project-root
     "Toggle current view to buffers with project root dir QUALIFIER."


### PR DESCRIPTION
Hello, this looks like a nice package. I made a couple of tweaks to make it much snappier, so please feel free to merge the PR.

- Use `buffer-local-value` to avoid `with-current-buffer`, since the former is much faster (see https://github.com/alphapapa/emacs-package-dev-handbook#accessing-buffer-local-variables)
- Cache the project root of each directory

The latter makes this package much faster on Windows Subsystem for Linux, where IO is slow.