### PR TITLE
Group tramp buffers by host

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ It's also possible to sort buffers by that column by calling `ibuffer-do-sort-by
               (ibuffer-do-sort-by-project-file-relative))))
 ```
 
+### Clearing the cache
+
+For performance, this package stores the locations of projects in memory. To clear the cache, run `ibuffer-project-clear-group-cache`.
+
 ## Installation
 
 ### With `package.el`

--- a/ibuffer-project.el
+++ b/ibuffer-project.el
@@ -77,8 +77,11 @@
     (let ((dir (buffer-local-value 'default-directory buf)))
       (when dir
         (or (gethash dir ibuffer-project-group-cache)
-            (let* ((root (cdr (project-current nil dir)))
+            (let* ((remote (tramp-handle-file-remote-p dir))
+                   (root (unless remote
+                           (cdr (project-current nil dir))))
                    (result (cond
+                            (remote (cons remote 'tramp))
                             (root (cons root 'project))
                             (dir (cons (abbreviate-file-name dir) 'directory)))))
               (puthash dir result ibuffer-project-group-cache)
@@ -87,9 +90,10 @@
 (defun ibuffer-project-group-name (root type)
   "Return group name for project ROOT and TYPE."
   (format "%s: %s"
-          (cl-case type
+          (cl-ecase type
+            (tramp "Remote")
             (project "Project")
-            (otherwise "Directory"))
+            (directory "Directory"))
           root))
 
 (define-ibuffer-filter project-root

--- a/ibuffer-project.el
+++ b/ibuffer-project.el
@@ -63,6 +63,14 @@
 (require 'ibuffer)
 (require 'ibuf-ext)
 
+(defcustom ibuffer-project-tramp-ignore-pattern
+  (rx bol "/" (or "sudo" "su") ":")
+  "Regexp pattern of paths that should not be grouped by TRAMP hosts.
+
+The default value matches any file path that begin with \"sudo\" or
+\"su\"."
+  :type 'regexp)
+
 (defvar ibuffer-project-group-cache (make-hash-table)
   "Cache for mappings from a directory to its group data.")
 
@@ -77,7 +85,8 @@
     (let ((dir (buffer-local-value 'default-directory buf)))
       (when dir
         (or (gethash dir ibuffer-project-group-cache)
-            (let* ((remote (tramp-handle-file-remote-p dir))
+            (let* ((remote (and (not (string-match-p ibuffer-project-tramp-ignore-pattern dir))
+                                (tramp-handle-file-remote-p dir)))
                    (root (unless remote
                            (cdr (project-current nil dir))))
                    (result (cond

--- a/ibuffer-project.el
+++ b/ibuffer-project.el
@@ -66,15 +66,19 @@
 (defun ibuffer-project-root (buf)
   "Return a cons cell (project-root . root-type) for BUF."
   (unless (string-match-p "^ " (buffer-name buf))
-    (with-current-buffer buf
-      (let ((dir (cdr (project-current))))
-        (cond
-         (dir (cons dir 'project))
-         (default-directory (cons (abbreviate-file-name default-directory) 'directory)))))))
+    (let* ((dir (buffer-local-value 'default-directory buf))
+           (root (when dir (cdr (project-current nil dir)))))
+      (cond
+       (root (cons root 'project))
+       (dir (cons (abbreviate-file-name dir) 'directory))))))
 
 (defun ibuffer-project-group-name (root type)
   "Return group name for project ROOT and TYPE."
-  (format "%s: %s" (if (eq type 'project) "Project" "Directory") root))
+  (format "%s: %s"
+          (cl-case type
+            (project "Project")
+            (otherwise "Directory"))
+          root))
 
 (define-ibuffer-filter project-root
     "Toggle current view to buffers with project root dir QUALIFIER."


### PR DESCRIPTION
This is a follow-up to #2. It groups tramp buffers by host rather than by project, while local buffers remain to be grouped by project.

This should be an optional feature, so I don't mind you reject this PR, but you could merge it.