### PR TITLE
Add guard in case dir of buffer is not/no longer readable.

### DIFF
--- a/ibuffer-project.el
+++ b/ibuffer-project.el
@@ -101,7 +101,8 @@ To clear cache use `ibuffer-project-clear-cache' command."
 
 (defun ibuffer-project-project-root (dir)
   "Get project root in DIR."
-  (let ((project (project-current nil dir)))
+  (let ((project (and (file-readable-p dir)
+					  (project-current nil dir))))
     (and project
          (if (functionp 'project-root)
              (project-root project)


### PR DESCRIPTION
In case the file/directory of an open buffer has been deleted/moved/made unreadable, calling `project-current` would throw an error `Opening directory: Not a directory`. This PR adds a guard against that situation.